### PR TITLE
fix copy argument

### DIFF
--- a/angrdbg/brk.py
+++ b/angrdbg/brk.py
@@ -57,6 +57,7 @@ def get_dbg_brk_linux32():
     code = '\xcd\x80' #int 0x80
 
     eax = debugger.get_reg("eax")
+    ebx = debugger.get_reg("ebx")
     ebp = debugger.get_reg("ebp")
     eip = debugger.get_reg("eip")
     efl = debugger.get_reg("efl")

--- a/angrdbg/memory.py
+++ b/angrdbg/memory.py
@@ -60,7 +60,7 @@ class SimSymbolicDbgMemory(SimMemory): #pylint:disable=abstract-method
     # Lifecycle management
     #
 
-    def copy(self):
+    def copy(self, memo=None):
         """
         Return a copy of the SimMemory.
         """


### PR DESCRIPTION
fix when angr calling `SimSimbolicDbgMemory.copy()` with memo argument
```
In [4]: m.explore(find=0x40050b)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
/home/ramdhan/tools/angrgdb/local/lib/python2.7/site-packages/angrgdb/commands.pyc in <module>()
----> 1 m.explore(find=0x40050b)

/home/ramdhan/tools/angrgdb/local/lib/python2.7/site-packages/angr/misc/immutability.pyc in _wrapper(self, *args, **kwargs)
     22         def _wrapper(self, *args, **kwargs):
     23             with cls.context(self) as self: #pylint:disable=redefined-argument-from-local
---> 24                 if method(self, *args, **kwargs) is not self:
     25                     raise ImmutabilityMixinMisused
     26                 return self

/home/ramdhan/tools/angrgdb/local/lib/python2.7/site-packages/angr/sim_manager.pyc in explore(self, stash, n, find, avoid, find_stash, avoid_stash, cfg, num_find, **kwargs)
    236
    237         try:
--> 238             self.run(stash=stash, n=n, **kwargs)
    239         finally:
    240             self.remove_technique(tech)

/home/ramdhan/tools/angrgdb/local/lib/python2.7/site-packages/angr/misc/immutability.pyc in _wrapper(self, *args, **kwargs)
     22         def _wrapper(self, *args, **kwargs):
     23             with cls.context(self) as self: #pylint:disable=redefined-argument-from-local
---> 24                 if method(self, *args, **kwargs) is not self:
     25                     raise ImmutabilityMixinMisused
     26                 return self

/home/ramdhan/tools/angrgdb/local/lib/python2.7/site-packages/angr/sim_manager.pyc in run(self, stash, n, until, **kwargs)
    258         for _ in (itertools.count() if n is None else xrange(0, n)):
    259             if not self.complete() and self._stashes[stash]:
--> 260                 self.step(stash=stash, **kwargs)
    261                 if not (until and until(self)):
    262                     continue

/home/ramdhan/tools/angrgdb/local/lib/python2.7/site-packages/angr/misc/hookset.pyc in __call__(self, *args, **kwargs)
     55                 next_hook = self.pending.pop()
     56                 self.pulled.append(next_hook)
---> 57                 result = next_hook(self.func.im_self, *args, **kwargs)
     58
     59             else:

/home/ramdhan/tools/angrgdb/local/lib/python2.7/site-packages/angr/exploration_techniques/explorer.pyc in step(self, simgr, stash, **kwargs)
     99     def step(self, simgr, stash='active', **kwargs):
    100         base_extra_stop_points = set(kwargs.get("extra_stop_points") or {})
--> 101         return simgr.step(stash=stash, extra_stop_points=base_extra_stop_points | self._extra_stop_points, **kwargs)
    102
    103     def filter(self, simgr, state, filter_func=None):

/home/ramdhan/tools/angrgdb/local/lib/python2.7/site-packages/angr/misc/hookset.pyc in __call__(self, *args, **kwargs)
     58
     59             else:
---> 60                 result = self.func(*args, **kwargs)
     61
     62         finally:

/home/ramdhan/tools/angrgdb/local/lib/python2.7/site-packages/angr/misc/immutability.pyc in _wrapper(self, *args, **kwargs)
     22         def _wrapper(self, *args, **kwargs):
     23             with cls.context(self) as self: #pylint:disable=redefined-argument-from-local
---> 24                 if method(self, *args, **kwargs) is not self:
     25                     raise ImmutabilityMixinMisused
     26                 return self

/home/ramdhan/tools/angrgdb/local/lib/python2.7/site-packages/angr/sim_manager.pyc in step(self, n, selector_func, step_func, stash, successor_func, until, filter_func, **run_args)
    339
    340             pre_errored = len(self._errored)
--> 341             successors = self.step_state(state, successor_func, **run_args)
    342             if not any(successors.itervalues()) and len(self._errored) == pre_errored:
    343                 bucket['deadended'].append(state)

/home/ramdhan/tools/angrgdb/local/lib/python2.7/site-packages/angr/sim_manager.pyc in step_state(self, state, successor_func, **run_args)
    360         """
    361         try:
--> 362             successors = self.successors(state, successor_func, **run_args)
    363             stashes = {None: successors.flat_successors,
    364                        'unsat': successors.unsat_successors,

/home/ramdhan/tools/angrgdb/local/lib/python2.7/site-packages/angr/sim_manager.pyc in successors(self, state, successor_func, **run_args)
    399         if successor_func is not None:
    400             return successor_func(state, **run_args)
--> 401         return self._project.factory.successors(state, **run_args)
    402
    403     #

/home/ramdhan/tools/angrgdb/local/lib/python2.7/site-packages/angr/factory.pyc in successors(self, *args, **kwargs)
     59         """
     60
---> 61         return self.project.engines.successors(*args, **kwargs)
     62
     63     def blank_state(self, **kwargs):

/home/ramdhan/tools/angrgdb/local/lib/python2.7/site-packages/angr/engines/hub.pyc in successors(self, state, addr, jumpkind, default_engine, procedure_engine, engines, **kwargs)
    126         for engine in engines:
    127             if engine.check(state, **kwargs):
--> 128                 r = engine.process(state, **kwargs)
    129                 if r.processed:
    130                     return r

/home/ramdhan/tools/angrgdb/local/lib/python2.7/site-packages/angr/engines/vex/engine.pyc in process(self, state, irsb, skip_stmts, last_stmt, whitelist, inline, force_addr, insn_bytes, size, num_inst, traceflags, thumb, opt_level, **kwargs)
    133                 traceflags=traceflags,
    134                 thumb=thumb,
--> 135                 opt_level=opt_level)
    136
    137     def _check(self, state, *args, **kwargs):

/home/ramdhan/tools/angrgdb/local/lib/python2.7/site-packages/angr/engines/engine.pyc in process(self, state, *args, **kwargs)
     33         # make a copy of the initial state for actual processing, if needed
     34         if not inline and o.COW_STATES in state.options:
---> 35             new_state = state.copy()
     36         else:
     37             new_state = state

/home/ramdhan/tools/angrgdb/local/lib/python2.7/site-packages/angr/sim_state.pyc in copy(self)
    438             raise SimStateError("global condition was not cleared before state.copy().")
    439
--> 440         c_plugins = self._copy_plugins()
    441         state = SimState(project=self.project, arch=self.arch, plugins=c_plugins, options=self.options.copy(),
    442                          mode=self.mode, os_name=self.os_name)

/home/ramdhan/tools/angrgdb/local/lib/python2.7/site-packages/angr/sim_state.pyc in _copy_plugins(self)
    425                 out[n] = memo[id(p)]
    426             else:
--> 427                 out[n] = p.copy(memo)
    428                 memo[id(p)] = out[n]
    429

TypeError: copy() takes exactly 1 argument (2 given)
```
reference:
https://github.com/angr/angr/blob/master/angr/sim_state.py#L427

fix undefined variable ebx:
https://github.com/andreafioraldi/angrdbg/blob/master/angrdbg/brk.py#L84