### PR TITLE
Constraint solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,4 @@ You can change the memory type with `set_memory_type`.
 ## Frontends
 + GDB -> [angrgdb](https://github.com/andreafioraldi/angrgdb)
 + IDA Pro debugger -> [IDAngr](https://github.com/andreafioraldi/IDAngr)
++ radare2 -> [r2angrdbg](https://github.com/andreafioraldi/r2angrdbg)

--- a/angrdbg/core.py
+++ b/angrdbg/core.py
@@ -107,6 +107,7 @@ class StateManager(object):
             raise ValueError(
                 "key must be a register name or a memory address, not %s" % str(
                     type(key)))
+        return key
 
     def sim_from_set(self, simset):
         for key in simset.symbolics:
@@ -135,6 +136,12 @@ class StateManager(object):
 
     def simulation_manager(self):
         return load_project().factory.simulation_manager(self.state)
+
+    def get_symbolic(self, key):
+        return self.symbolics.get(key)
+
+    def get_state(self):
+        return self.state
 
     def to_dbg(self, found_state):
         if isinstance(found_state, StateManager):


### PR DESCRIPTION
Hi,
I was playing around with r2angrdbg and noticed the lack of options to constrain the initial state.

I added these options together with an example in the r2angrdbg repo.
Please let me know what you think of my edit (maybe there's a more elegant way?).